### PR TITLE
Check if records is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "shire"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shire"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Willow GHOST <ghostdevbusiness@gmail.com> (willow.sh)"]
 description = "Shire is a simple no fuss ddns client for Cloudflare"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ struct Args {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
+    if args.records.is_empty() {
+        println!("No records specified, exiting...");
+        return Ok(());
+    }
+
     println!("Fetching record data...");
     let records = records::get_records(&args.zone_id, &args.key).await?;
 


### PR DESCRIPTION
To prevent shire doing anything if there are no records, clap doesn't seem to require the Vec have a length - it may be possible to get clap to check that but happy with this fix for now